### PR TITLE
demonstrate additional folders ending up in a built container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ wheels/
 .venv
 
 .ruff_cache
+.pytest_cache

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,16 +2,27 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug: App",
+            "name": "Debug Project",
             "type": "debugpy",
             "request": "launch",
             "module": "uvicorn",
             "args": [
-                "src.app:app",
+                "src.${input:project-name}:app",
                 "--reload"
             ],
             "jinja": true,
-            "cwd": "${workspaceFolder}/projects/app"
+            "cwd": "${workspaceFolder}/projects/${input:project-name}"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "project-name",
+            "type": "pickString",
+            "options": [
+                "app"
+            ],
+            "description": "The project inside the `projects` folder to attach the debugger.",
+            "default": "app"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -1,82 +1,128 @@
-Inspired (read: hijacked) from https://gafni.dev/blog/cracking-the-python-monorepo/
+# Python Monorepo Experiment
+---
 
-Necessary to install:
+> [!NOTE]
+> Inspired (read: hijacked) from https://gafni.dev/blog/cracking-the-python-monorepo/
+
+
+This experiment is an exercise in exploring an option for managing a python monorepo. Nothing this repo accomplishes is extraordinary in comparison to what can be accomplished with other routes using a tool like Bazel. However, Bazel is a pretty heavy lift that can be hard to win over other engineers with. The primary advantage of this experiment is to look at the quantity of effort it takes to monorepo with these tools in hopes that less push-back is given. Pants may be a valid alternative but the apparent lack of first class support for debugging and import suggestions and autocomplete in visual studio code makes it less appealing.
+
+### The general goals of this repo:
+- Small and low overhead solution or toolchain. Ideally workable for a small (single digit) sized team with only a subset actively touching any apps.
+- Small shippables. Serverless is the intended target, the environment it is to enter spends near 50% of its time idle.
+- Reduce duplication and copy/paste drift. Without a monorepo, the overhead of shipping individual packages and dealing with packaging is more than the small team is ready to take on. As a side effect, duplicated code and drift on them.
+- Avoid steep learning curve tools. Not everyone is at the same level of exposure to some of the tooling options, and still need to be able to pick them up.
+- Facilitate a conglomerate of small shippable artifacts to keep build and iteration times low, reduce blast radius of changes and hide domain complexity. (The domain is harder than the engineering complexity of more things...)
+- Rapidly cloneable github workflows. Onboarding a new shippable artifact raises eyebrows if it takes a significant portion of time, so the intent is to make it short enough that it isn't noticed.
+- Type-ahead and import suggestions and ability to attach a debugger are non-negotiable. Any set up that loses those three aspects is immediately not worth it.
+- Few to none of the unexpected gotchyas (the pip workflow with editable or non-updating dependencies comes to mind)
+
+### Getting set up:
+
+#### Necessary to install:
 - [uv](https://docs.astral.sh/uv/): for managing the dependencies. Using `uv` enables support for local editable installs.
 - [docker (or docker compatible tool)](https://www.docker.com/): the runtime for containers that are used to execute CI tasks for this project and the containers it will ship.
 - [dagger](https://docs.dagger.io/): a tool to manage and build containers in utilizing python
 
-Optional to install:
+#### Optional to install:
 - [act](https://nektosact.com/usage/index.html): some level of validation before pushing a workflow file
 
-Adding a new library:
-```sh
-uv init --package --lib libs/lib3
-```
+### Adding more things:
+- Adding a new library:
+    ```sh
+    uv init --package --lib libs/lib3
+    ```
 
-Adding a new service:
-```sh
-uv init --package projects/app
-```
+- Adding a new service:
+    ```sh
+    uv init --package projects/app
+    ```
 
-Adding a new dependency:
-```sh
-uv add --package app lib1
-```
+- Adding a new dependency:
+    ```sh
+    uv add --package app lib1
+    ```
 
-Running fastapi container locally, see `.dagger/src/monorepo_dagger/main.py`
+### Executing things:
 
-```sh
-dagger call fastapi-run --port 8081 --root-dir . --project app up
-```
+- Running a FastAPI container locally, see `.dagger/src/monorepo_dagger/main.py`
+    ```sh
+    dagger -v call fastapi-distroless-run --project app up
+    ```
 
-Publishing fastapi container, see `.dagger/src/monorepo_daggger/main.py`
+- Running tests:
+    ```sh
+    dagger call pytest --project app
+    ```
 
-```sh
-dagger call fastapi-publish --root-dir . --project app --dev
-```
+- Publishing FastAPI container, see `.dagger/src/monorepo_daggger/main.py`
+    ```sh
+    dagger -v call fastapi-distroless-publish --project app --registry ttl.sh --image python-monorepo --tag 20m
+    ```
 
-Debugging a project from inside vscode (launch.json):
-```json
-{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Debug: App", // TODO: smarter way of finding which project to run?
-            "type": "debugpy",
-            "request": "launch",
-            "module": "uvicorn",
-            "args": [
-                "app:app",
-                "--reload"
-            ],
-            "jinja": true,
-            "cwd": "${workspaceFolder}/app"
-        }
-    ]
-}
-```
+- Testing workflow for github:
 
-Getting auto complete and auto imports in vscode (settings.json):
-```json
-{
-    "python.autoComplete.extraPaths": [
-        "./libs/lib1/src",
-        "./libs/lib2/src"
-    ],
-    "python.analysis.extraPaths": [
-        "./libs/lib1/src",
-        "./libs/lib2/src"
-    ]
-}
-```
+    ```sh
+    act pull_request --container-architecture linux/amd64
+    ```
 
-Running tests:
-```sh
-dagger call pytest --project app
-```
+### Getting configured for work
 
-Testing workflow for github:
+- Debugging a project from inside vscode (launch.json):
+    ```json
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Debug Project",
+                "type": "debugpy",
+                "request": "launch",
+                "module": "uvicorn",
+                "args": [
+                    "src.${input:project-name}:app",
+                    "--reload"
+                ],
+                "jinja": true,
+                "cwd": "${workspaceFolder}/projects/${input:project-name}"
+            }
+        ],
+        "inputs": [
+            {
+                "id": "project-name",
+                "type": "pickString",
+                "options": [
+                    "app"
+                ],
+                "description": "The project inside the `projects` folder to attach the debugger.",
+                "default": "app"
+            }
+        ]
+    }
 
-```sh
-act pull_request --container-architecture linux/amd64
-```
+    ```
+
+- Getting auto complete and auto imports in vscode (settings.json):
+    ```json
+    {
+        "python.autoComplete.extraPaths": [
+            "./libs/lib1/src",
+            "./libs/lib2/src"
+        ],
+        "python.analysis.extraPaths": [
+            "./libs/lib1/src",
+            "./libs/lib2/src"
+        ]
+    }
+    ```
+
+- Wiring up unit testing for attaching debuggers (settings.json):
+    ```json
+    {
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+            // need a new entry for each package that is going to have tests
+            "projects/app"
+        ]
+    }
+    ```

--- a/projects/app/pyproject.toml
+++ b/projects/app/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "fastapi[standard]>=0.115.11",
+    "jinja2>=3.1.6",
     "lib1",
 ]
 

--- a/projects/app/src/app/__init__.py
+++ b/projects/app/src/app/__init__.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.templating import Jinja2Templates
 import lib1
 
 app = FastAPI()
@@ -6,6 +7,8 @@ app = FastAPI()
 
 stuff = "things"
 
+templates = Jinja2Templates(directory="templates")
+
 @app.get("/")
-def read_root():
-     return {lib1.hello(): "Hello from app."}
+def read_root(request: Request):
+     return templates.TemplateResponse(request=request, name="template.jinja", context={"first": lib1.hello(), "second": "Hello from app."})

--- a/projects/app/templates/template.jinja
+++ b/projects/app/templates/template.jinja
@@ -1,0 +1,1 @@
+{{ first }} & {{ second }}

--- a/uv.lock
+++ b/uv.lock
@@ -40,12 +40,14 @@ version = "0.1.0"
 source = { editable = "projects/app" }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "jinja2" },
     { name = "lib1" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.11" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "lib1", editable = "libs/lib1" },
 ]
 


### PR DESCRIPTION
additional folders for things like templates are often shipped alongside the app to handle certain pages. This hooks up an example of using a template folder alongside fastapi using the jinja templates and ships them to the runtime container